### PR TITLE
FIX: RegularShape, app-conf Font, more map settings in app-conf

### DIFF
--- a/app/client/index.html
+++ b/app/client/index.html
@@ -6,8 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
     <title>mapkit</title>
-    <!-- ADD CUSTOM FONT BELOW -->
-    <!-- <link href="https://fonts.googleapis.com/css2?family=Zen+Dots&display=swap" rel="stylesheet"> -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css" />
     <script src="https://use.fontawesome.com/facf9fa52c.js"></script>
   </head>

--- a/app/client/public/static/app-conf.json
+++ b/app/client/public/static/app-conf.json
@@ -42,7 +42,6 @@
         "url": "./geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typename=workspace1:points&outputFormat=application/json&srsname=EPSG:3857",
         "group": "media",
         "queryable": true,
-        "displayInLegend": false,
         "format": "GeoJSON",
         "legendDisplayName": "Points",
         "visible": true,
@@ -57,7 +56,7 @@
           "radius": 10,
           "strokeWidth": 2,
           "stylePropFnRef": {
-            "fillColor": "variable1",
+            "fillColor": "variable1",                       
             "strokeColor": "variable2"
           },
           "hoverTextColor": "white",
@@ -217,7 +216,7 @@
           "hoverBackgroundColor": "#000000",
           "stylePropFnRef": {
             "fillColor": "variable1",
-            "circleRadiusFn": "variable2"
+            "circleRadius": "variable2"
           },
           "strokeColor": "rgba(255,255,255,0.7)",
           "strokeWidth": 1

--- a/app/client/public/static/app-conf.json
+++ b/app/client/public/static/app-conf.json
@@ -1,11 +1,13 @@
 {
   "app": {
     "title": "Crystalball",
+    "tagline": "open-source mapkit",
     "projectWebsite": "https://wiki.timetochange.today",
     "color": {
       "primary": "#00000e",
       "secondary": "red"
     },
+
     "legend": {
       "isVisible": false
     },
@@ -35,6 +37,8 @@
       38.219, 19.109, 9.5546, 4.7773, 2.3887, 1.1943, 0.5972
     ],
     "center": [0, 0],
+    "minResolution": 0.25,
+    "maxResolution": 64000,
     "layers": [
       {
         "type": "VECTOR",
@@ -56,7 +60,7 @@
           "radius": 10,
           "strokeWidth": 2,
           "stylePropFnRef": {
-            "fillColor": "variable1",                       
+            "fillColor": "variable1",
             "strokeColor": "variable2"
           },
           "hoverTextColor": "white",

--- a/app/client/public/static/app-conf.json
+++ b/app/client/public/static/app-conf.json
@@ -220,7 +220,7 @@
           "hoverBackgroundColor": "#000000",
           "stylePropFnRef": {
             "fillColor": "variable1",
-            "circleRadius": "variable2"
+            "radius": "variable2"
           },
           "strokeColor": "rgba(255,255,255,0.7)",
           "strokeWidth": 1

--- a/app/client/src/App.vue
+++ b/app/client/src/App.vue
@@ -5,3 +5,16 @@
     </keep-alive>
   </div>
 </template>
+<script>
+export default {
+  name: 'App',
+  beforeCreate() {
+    if (this.$appConfig.app.font && this.$appConfig.app.font.url) {
+      const link = document.createElement('link');
+      link.href = `${this.$appConfig.app.font.url}`;
+      link.rel = 'stylesheet';
+      document.head.appendChild(link);
+    }
+  },
+};
+</script>

--- a/app/client/src/assets/scss/app.scss
+++ b/app/client/src/assets/scss/app.scss
@@ -31,8 +31,8 @@ body,
 .wg-app {
   position: relative;
   width: 100%;
-  // font-family: 'Zen Dots'; Uncomment this line to change the custom fongs "Change 'Zen Dots' to your font name
 }
+
 .wg-app-embedded {
   width: 100%;
   height: 100%;

--- a/app/client/src/components/viewer/ol/Map.vue
+++ b/app/client/src/components/viewer/ol/Map.vue
@@ -801,7 +801,7 @@ export default {
         if (me.activeInteractions.length > 0) {
           return;
         }
-        if (me.isEditingLayer || me.isEditingPost) {
+        if (me.isEditingLayer) {
           return;
         }
         let feature;
@@ -839,9 +839,9 @@ export default {
         }
 
         me.closePopup();
-        EventBus.$emit('clearEditHtml');
+        // EventBus.$emit('clearEditHtml');
 
-        if (this.selectedCoorpNetworkEntity && !layer) {
+        if ((this.selectedCoorpNetworkEntity || me.isEditingPost || me.isEditingHtml) && !layer) {
           return;
         }
 
@@ -927,13 +927,16 @@ export default {
             this.popup.activeFeature.setId(`clone.${feature.getId()}`);
           }
 
-          if (this.selectedCoorpNetworkEntity && this.popup.activeFeature) {
+          if (
+            (this.selectedCoorpNetworkEntity || this.isEditingPost || this.isEditingHtml) &&
+            this.popup.activeFeature
+          ) {
             this.popup.highlightLayer.getSource().clear();
             this.popup.activeFeature.setStyle(null);
             this.popup.highlightLayer.getSource().addFeature(this.popup.activeFeature);
           }
 
-          if (this.selectedCoorpNetworkEntity) {
+          if (this.selectedCoorpNetworkEntity || this.isEditingPost || this.isEditingHtml) {
             this.showPopup(evt.coordinate);
           } else {
             this.zoomToFeature();

--- a/app/client/src/components/viewer/ol/Map.vue
+++ b/app/client/src/components/viewer/ol/Map.vue
@@ -230,6 +230,8 @@ export default {
     return {
       zoom: this.$appConfig.map.zoom,
       center: this.$appConfig.map.center,
+      minResolution: this.$appConfig.map.minResolution,
+      maxResolution: this.$appConfig.map.maxResolution,
       minZoom: this.$appConfig.map.minZoom,
       maxZoom: this.$appConfig.map.maxZoom,
       extent: this.$appConfig.map.extent,
@@ -349,8 +351,8 @@ export default {
       }).extend([attribution]),
       view: new View({
         center: me.center || [0, 0],
-        minResolution: 0.25,
-        maxResolution: 64000,
+        minResolution: me.minResolution || 0.25,
+        maxResolution: me.maxResolution || 64000,
       }),
     });
     // Add map to the vuex store.

--- a/app/client/src/components/viewer/ol/controls/AddPost.vue
+++ b/app/client/src/components/viewer/ol/controls/AddPost.vue
@@ -13,6 +13,7 @@
     <v-alert v-if="currentResolution && currentResolution > minResolution" dense border="left" type="warning"
       >Zoom in close to add your post.</v-alert
     >
+    <confirm-unsave ref="confirm" :color="color"></confirm-unsave>
   </div>
 </template>
 
@@ -22,11 +23,15 @@ import {mapFields} from 'vuex-map-fields';
 
 import Feature from 'ol/Feature';
 import Point from 'ol/geom/Point';
+import ConfirmDialog from '../../../core/ConfirmDialog.vue';
 
 export default {
   props: {
     map: {type: Object, required: true},
     color: {type: String},
+  },
+  components: {
+    'confirm-unsave': ConfirmDialog,
   },
   data() {
     return {};
@@ -48,7 +53,9 @@ export default {
     },
   },
   methods: {
-    addPost() {
+    enablePostEdit() {
+      this.isEditingHtml = false;
+      this.htmlContent = '';
       const feature = new Feature({
         geom: new Point(this.map.getView().getCenter()),
         icon: '',
@@ -57,6 +64,21 @@ export default {
       this.postEditLayer.getSource().clear();
       this.postEditLayer.getSource().addFeature(feature);
       this.postFeature = feature;
+    },
+    addPost() {
+      if (this.isEditingHtml) {
+        this.$refs.confirm
+          .open('Warning', 'You have unsaved changes! Are you sure you want to continue?', 'Yes', 'Cancel', {
+            color: this.color,
+          })
+          .then(confirm => {
+            if (confirm) {
+              this.enablePostEdit();
+            }
+          });
+      } else {
+        this.enablePostEdit();
+      }
     },
   },
 };

--- a/app/client/src/style/OlStyleDefs.js
+++ b/app/client/src/style/OlStyleDefs.js
@@ -233,12 +233,12 @@ export function baseStyle(config) {
         strokeWidth,
         lineDash,
         label,
-        circleRadius2,
-        circleRadiusFn,
+        radius,
+        radius2,
         points,
         angle,
         iconUrl,
-        iconScaleFn,
+        iconScale,
         scale,
         opacity,
         iconAnchor,
@@ -280,7 +280,7 @@ export function baseStyle(config) {
         case 'Point':
         case 'MultiPoint': {
           let style;
-          if (iconUrl || iconScaleFn) {
+          if (iconUrl || iconScale) {
             const options = {
               image: new OlIconStyle({
                 src:
@@ -288,8 +288,8 @@ export function baseStyle(config) {
                     ? iconUrl(feature.get(stylePropFnRef.iconUrl))
                     : iconUrl,
                 scale:
-                  stylePropFnRef && stylePropFnRef.iconScaleFn && iconScaleFn
-                    ? iconScaleFn(feature.get(stylePropFnRef.iconScaleFn))
+                  stylePropFnRef && stylePropFnRef.iconScale && iconScale
+                    ? iconScale(feature.get(stylePropFnRef.iconScale))
                     : scale || 1,
                 opacity: opacity || 1,
                 anchor: iconAnchor,
@@ -320,9 +320,9 @@ export function baseStyle(config) {
                     : fillColor || 'rgba(129, 56, 17, 0.7)',
               }),
               radius:
-                stylePropFnRef && stylePropFnRef.circleRadiusFn && circleRadiusFn instanceof Function
-                  ? circleRadiusFn(feature.get(stylePropFnRef.circleRadiusFn))
-                  : 5,
+                stylePropFnRef && stylePropFnRef.radius && radius instanceof Function
+                  ? radius(feature.get(stylePropFnRef.radius))
+                  : radius || 5,
             };
             let image;
             if (config.type === 'circle') {
@@ -333,9 +333,9 @@ export function baseStyle(config) {
               image = new OlRegularShape({
                 ...baseImageOptions,
                 radius2:
-                  stylePropFnRef && stylePropFnRef.circleRadius2 && circleRadius2 instanceof Function
-                    ? circleRadius2(feature.get(stylePropFnRef.circleRadius2))
-                    : circleRadius2,
+                  stylePropFnRef && stylePropFnRef.radius2 && radius2 instanceof Function
+                    ? radius2(feature.get(stylePropFnRef.radius2))
+                    : radius2,
                 points:
                   stylePropFnRef && stylePropFnRef.points && points instanceof Function
                     ? points(feature.get(stylePropFnRef.points))
@@ -511,12 +511,17 @@ export const styleRefs = {
 };
 
 export const defaultLimits = {
-  iconScaleFn: {
+  iconScale: {
     smallestDefaultScale: 0.2,
     largestDefaultScale: 1,
     defaultMultiplier: 603000,
   },
-  circleRadiusFn: {
+  radius: {
+    smallestDefaultRadius: 5,
+    largestDefaultRadius: 30,
+    defaultMultiplier: 0.3,
+  },
+  radius2: {
     smallestDefaultRadius: 5,
     largestDefaultRadius: 30,
     defaultMultiplier: 0.3,
@@ -559,7 +564,7 @@ function stringDivider(str, width, spaceReplacer) {
 }
 
 const getIconScaleValue = (propertyValue, multiplier, smallestScale, largestScale) => {
-  const {smallestDefaultScale, largestDefaultScale, defaultMultiplier} = defaultLimits.iconScaleFn;
+  const {smallestDefaultScale, largestDefaultScale, defaultMultiplier} = defaultLimits.iconScale;
   const smallestValue = smallestScale || smallestDefaultScale;
   const largestValue = largestScale || largestDefaultScale;
   let scale = propertyValue / (multiplier || defaultMultiplier);
@@ -573,7 +578,7 @@ const getIconScaleValue = (propertyValue, multiplier, smallestScale, largestScal
 };
 
 const getRadiusValue = (propertyValue, multiplier, smallestRadius, largestRadius, defaultMultiplier) => {
-  const {smallestDefaultRadius, largestDefaultRadius} = defaultLimits.circleRadiusFn;
+  const {smallestDefaultRadius, largestDefaultRadius} = defaultLimits.radius;
   const smallestValue = smallestRadius || smallestDefaultRadius;
   const largestValue = largestRadius || largestDefaultRadius;
   let radius = Math.sqrt(propertyValue) * multiplier || defaultMultiplier;
@@ -588,13 +593,13 @@ const getRadiusValue = (propertyValue, multiplier, smallestRadius, largestRadius
 
 export const layersStylePropFn = {
   default: {
-    iconScaleFn: propertyValue => getIconScaleValue(propertyValue),
-    circleRadiusFn: propertyValue => getRadiusValue(propertyValue),
+    iconScale: propertyValue => getIconScaleValue(propertyValue),
+    radius: propertyValue => getRadiusValue(propertyValue),
     iconUrl: propertyValue => propertyValue,
   },
   glri_projects: {
     fillColor: propertyValue => propertyValue,
-    circleRadiusFn: propertyValue => getRadiusValue(propertyValue, 0.012),
+    radius: propertyValue => getRadiusValue(propertyValue, 0.012),
   },
   polygons: {
     strokeColor: propertyValue => propertyValue,

--- a/app/client/src/views/Admin.vue
+++ b/app/client/src/views/Admin.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-app id="inspire">
+  <v-app
+    id="inspire"
+    :style="`font-family:${
+      $appConfig.app.font && $appConfig.app.font.family ? $appConfig.app.font.family : 'Roboto'
+    }, 'Roboto', serif;`"
+  >
     <v-navigation-drawer v-model="drawer" app clipped>
       <v-list dense>
         <div :key="item.text" v-for="item in items">

--- a/app/client/src/views/Main.vue
+++ b/app/client/src/views/Main.vue
@@ -1,7 +1,15 @@
 <template>
   <div id="site-wrap">
     <!-- ===DESKTOP=== -->
-    <v-app v-if="!$vuetify.breakpoint.smAndDown" id="wg-app" data-app :class="{'wg-app': true}">
+    <v-app
+      v-if="!$vuetify.breakpoint.smAndDown"
+      id="wg-app"
+      data-app
+      :class="{'wg-app': true}"
+      :style="`font-family:${
+        $appConfig.app.font && $appConfig.app.font.family ? $appConfig.app.font.family : 'Roboto'
+      }, 'Roboto', serif;`"
+    >
       <template>
         <v-expand-transition>
           <v-navigation-drawer
@@ -89,7 +97,7 @@
 
         <v-spacer></v-spacer><v-spacer></v-spacer>
 
-        <span class="title pr-5">open-source mapkit</span>
+        <span class="title pr-5">{{ $appConfig.app.tagline || '' }}</span>
         <v-btn icon @click.stop="sidebarState = !sidebarState"
           ><v-icon medium>{{ sidebarState ? '$close' : '$menu' }}</v-icon></v-btn
         >


### PR DESCRIPTION
This PR contains the following changes:
 
- Adds the RegularShape option in app-conf. For this the following json structure can be defined: 

```
 "style": {
          "type": "RegularShape",
          "radius": 10,
          "radius2": 5,
          "points": 5,
          "strokeWidth": 2,
          "stylePropFnRef": {
            "fillColor": "variable1",
            "strokeColor": "variable2"
          },
 
```
!!!! The following properties have been renamed in app-conf: 

**iconScaleFn => iconScale** 
**circleRadiusFn => radius**

!!!!!!!

- Fix #35 

1- Adds the option to define Font family directly from app-conf. 
This can be defined inside the "app" object like below: 

```
app: {
...
    "font": {
      "url": "https://fonts.googleapis.com/css2?family=Zen+Dots&display=swap",
      "family": "Zen Dots"
    },
...
}
```
} 

2- Add minResolution and maxResolution
```
...
   "resolutions": [
      156543.03, 78271.52, 39135.76, 19567.88, 9783.94, 4891.97, 2445.98, 1222.99, 611.5, 305.75, 152.87, 76.437,
      38.219, 19.109, 9.5546, 4.7773, 2.3887, 1.1943, 0.5972
    ],
    "center": [0, 0],
    **"minResolution": 0.25,
    "maxResolution": 64000,**
...

```

3- Add tagline
```
...
  "app": {
    "title": "Crystalball",
    "tagline": "open-source mapkit",
...
```





- Fix #37 


