### PR TITLE
fix: colormap

### DIFF
--- a/app/client/src/factory/OlLayer.js
+++ b/app/client/src/factory/OlLayer.js
@@ -116,8 +116,8 @@ export const LayerFactory = {
         }
       });
       // Overwrite fillColor if colorMapStyle is set
-      if (stylePropFnRef.fillColorFn === "colorMapStyle") {
-        stylePropFn.fillColor = colorMapFn(layerName)
+      if (stylePropFnRef.fillColorFn === 'colorMapStyle') {
+        stylePropFn.fillColor = colorMapFn(layerName);
       }
       const props = {...styleProps, ...stylePropFn, layerName};
       return styleFn(props, layerName);

--- a/app/client/src/factory/OlLayer.js
+++ b/app/client/src/factory/OlLayer.js
@@ -21,7 +21,7 @@ import Cluster from 'ol/source/Cluster';
 import {Image as ImageLayer} from 'ol/layer';
 import XyzSource from 'ol/source/XYZ';
 import {OlStyleFactory} from './OlStyle';
-import {styleRefs, layersStylePropFn} from '../style/OlStyleDefs';
+import {styleRefs, layersStylePropFn, colorMapFn} from '../style/OlStyleDefs';
 import http from '../services/http';
 
 /**
@@ -115,17 +115,14 @@ export const LayerFactory = {
           stylePropFn[fnName] = fn;
         }
       });
+      // Overwrite fillColor if colorMapStyle is set
+      if (stylePropFnRef.fillColorFn === "colorMapStyle") {
+        stylePropFn.fillColor = colorMapFn(layerName)
+      }
       const props = {...styleProps, ...stylePropFn, layerName};
       return styleFn(props, layerName);
     }
-    if (styleRef) {
-      // Edge case for colormap palete
-      if (styleRef === 'colorMapStyle') {
-        return styleRefs[styleRef](layerName, styleProps.colorField, styleProps.colormap);
-      }
-      return styleRefs[styleRef](layerName);
-    }
-    // Just a generic style
+
     return OlStyleFactory.getInstance(styleProps);
   },
 

--- a/app/client/src/store/modules/map.js
+++ b/app/client/src/store/modules/map.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-param-reassign */
-import { getField, updateField } from 'vuex-map-fields';
+import {getField, updateField} from 'vuex-map-fields';
 import axios from 'axios';
 import colormap from 'colormap';
-import { Group as LayerGroup } from 'ol/layer';
-import { formatPopupRows, getLayerSourceUrl, extractGeoserverLayerNames, getAllChildLayers } from '../../utils/Layer';
+import {Group as LayerGroup} from 'ol/layer';
+import {formatPopupRows, getLayerSourceUrl, extractGeoserverLayerNames} from '../../utils/Layer';
 import http from '../../services/http';
 
 const state = {
@@ -100,7 +100,7 @@ const state = {
   editType: null,
   editLayer: null,
   highlightLayer: null,
-  isTranslating: false
+  isTranslating: false,
 };
 
 const getters = {
@@ -188,20 +188,20 @@ const getters = {
 };
 
 const actions = {
-  fetchColorMapEntities({ commit, rootState }) {
+  fetchColorMapEntities({commit, rootState}) {
     // eslint-disable-next-line no-undef
     if (!rootState.map.colorMapEntities) {
       return;
     }
-    const layers = {}
+    const layers = {};
     Object.keys(rootState.map.layers).forEach(key => {
       const layer = rootState.map.layers[key];
       if (layer instanceof LayerGroup) {
         const layersArray = layer.getLayers().getArray();
         layersArray.forEach(l => {
-          console.log(l.get('name'))
+          console.log(l.get('name'));
           layers[l.get('name')] = l;
-        })
+        });
       } else {
         layers[layer.get('name')] = layer;
       }
@@ -212,7 +212,11 @@ const actions = {
       if (layer.get('styleObj')) {
         const styleObj = JSON.parse(layer.get('styleObj'));
         if (!styleObj.stylePropFnRef) return;
-        if (styleObj.stylePropFnRef.fillColorFn !== "colorMapStyle" || rootState.map.colorMapEntities[layer.get('name')]) return;
+        if (
+          styleObj.stylePropFnRef.fillColorFn !== 'colorMapStyle' ||
+          rootState.map.colorMapEntities[layer.get('name')]
+        )
+          return;
         const tableName =
           styleObj.tableName ||
           extractGeoserverLayerNames([
@@ -260,7 +264,7 @@ const actions = {
               const entity = feature.properties.entity;
               entities[entity] = colors[index];
             });
-            commit('SET_COLORMAP_VALUES', { layerName, entities });
+            commit('SET_COLORMAP_VALUES', {layerName, entities});
             const layers = state.map.getLayers().getArray();
             layers.forEach(layer => {
               if (layer.get('name') === layerName) {

--- a/app/client/src/style/OlStyleDefs.js
+++ b/app/client/src/style/OlStyleDefs.js
@@ -9,10 +9,10 @@ import OlRegularShape from 'ol/style/RegularShape';
 import OlIconStyle from 'ol/style/Icon';
 import OlText from 'ol/style/Text';
 import store from '../store/modules/map';
-import { OlStyleFactory } from '../factory/OlStyle';
+import {OlStyleFactory} from '../factory/OlStyle';
 
 // Resets cache when map groups is changed.
-import { EventBus } from '../EventBus';
+import {EventBus} from '../EventBus';
 
 const strokeColor = 'rgba(236, 236, 236, 0.7)';
 const fillColor = 'rgba(255,0,0, 0.2)';
@@ -349,7 +349,7 @@ export function baseStyle(config) {
           text: getText(feature.get(label.text), resolution, label.maxResolution || 1200, placement),
           offsetX: label.offsetX || 12,
           offsetY: label.offsetY || 0,
-          fill: new OlFill({ color: label.fill.color || 'black' }),
+          fill: new OlFill({color: label.fill.color || 'black'}),
           stroke: new OlStroke({
             color: label.stroke.color || 'white',
             width: label.stroke.width || 3,
@@ -604,7 +604,7 @@ function stringDivider(str, width, spaceReplacer) {
 }
 
 const getIconScaleValue = (propertyValue, multiplier, smallestScale, largestScale) => {
-  const { smallestDefaultScale, largestDefaultScale, defaultMultiplier } = defaultLimits.iconScale;
+  const {smallestDefaultScale, largestDefaultScale, defaultMultiplier} = defaultLimits.iconScale;
   const smallestValue = smallestScale || smallestDefaultScale;
   const largestValue = largestScale || largestDefaultScale;
   let scale = propertyValue / (multiplier || defaultMultiplier);
@@ -618,7 +618,7 @@ const getIconScaleValue = (propertyValue, multiplier, smallestScale, largestScal
 };
 
 const getRadiusValue = (propertyValue, multiplier, smallestRadius, largestRadius, defaultMultiplier) => {
-  const { smallestDefaultRadius, largestDefaultRadius } = defaultLimits.radius;
+  const {smallestDefaultRadius, largestDefaultRadius} = defaultLimits.radius;
   const smallestValue = smallestRadius || smallestDefaultRadius;
   const largestValue = largestRadius || largestDefaultRadius;
   let radius = Math.sqrt(propertyValue) * multiplier || defaultMultiplier;
@@ -631,7 +631,7 @@ const getRadiusValue = (propertyValue, multiplier, smallestRadius, largestRadius
   return radius;
 };
 
-export const colorMapFn = (layerName) => {
+export const colorMapFn = layerName => {
   const colorFn = propertyValue => {
     const colors = store.state.colorMapEntities[layerName];
     const entity = propertyValue;
@@ -639,9 +639,9 @@ export const colorMapFn = (layerName) => {
       return colors[entity];
     }
     return '#00c8f0';
-  }
-  return colorFn
-}
+  };
+  return colorFn;
+};
 
 export const layersStylePropFn = {
   default: {


### PR DESCRIPTION
This PR fixes the colormap issues with layer groupS and also adds support for combining it with other style properties. 
The following changes are made in the way the colormaps are defined. 
Previously the colormap was defined in the root of the style property. With these new changes the colormap should be defined as as follows: 

```
        "minResolution": 1,
        "maxResolution": 64000,
        "hoverable": true,
        "style": {
          "hoverTextColor": "white",
          "hoverBackgroundColor": "black",
          "type": "circle",
          "stylePropFnRef": {
            "radius": "variable2",
            "fillColor": "variable2",
            "fillColorFn": "colorMapStyle",
            "fillColorMap": "jet"
          },
          "strokeColor": "#ffffff",
          "strokeWidth": 0.4
        }
      },
```
So to enable the colormap inside the stylePropFnRef object two properties should be defined: 
**fillColorFn="colorMapStyle"** and **fillColorMap="<COLORMAP_TYPE>"** o

