### PR TITLE
feat: add custom nshades for colormap

### DIFF
--- a/app/client/src/style/OlStyleDefs.js
+++ b/app/client/src/style/OlStyleDefs.js
@@ -259,6 +259,7 @@ export function baseStyle(config) {
     if (config.stylePropFnRef && config.stylePropFnRef.fillColorFn && !store.state.colorMapEntities[config.layerName]) {
       return [];
     }
+
     let _style;
     if (!styleCache[cacheId]) {
       const {


### PR DESCRIPTION
This PR adds the option to configure the nshades for colormaps and also define custom color. 

- nshades can be added as a optional parameter. If not added it will used the total length of number of features. 
For this, there is a new property named: `fillColorMapNshades: 10` in the stylePropFnRef which can be defined. This number needs to be larger or equal than the length of colormap definition. These defintions lengths are defined inside the colormap library, here: 
https://github.com/bpostlethwaite/colormap/blob/master/colorScale.js

It consist on an array of indexes with a rgb color value. It usually has the range of 5-15 color points. This is the minimum of nshades regarding number of features.

- To add a custom color instead of a build colormap code instead of specifying the name an array of color values needs to be defined, containing index and color. Same way as the colors are defined here https://github.com/bpostlethwaite/colormap/blob/master/colorScale.js and in the example below. 


Example: 

```

            "format": "MVT",
            "renderMode": "hybrid",
            "visible": true,
            "zIndex": 100,
            "minResolution": 0,
            "maxResolution": 400,
            "opacity": 0.99,
            "hoverable": true,
            "style": {
              "hoverTextColor": "white",
              "hoverBackgroundColor": "black",
              "type": "circle",
              "strokeColor": "white",
              "strokeWidth": 0.5,
              "stylePropFnRef": {
                "radius": "variable1",
                "fillColor": "variable1",
                "fillColorFn": "colorMapStyle",
                "fillColorMap": [
                  {
                    "index": 0,
                    "rgb": [0, 0, 4]
                  },
                  {
                    "index": 0.13,
                    "rgb": [28, 16, 68]
                  },
                  {
                    "index": 0.25,
                    "rgb": [79, 18, 123]
                  },
                  {
                    "index": 0.38,
                    "rgb": [129, 37, 129]
                  },
                  {
                    "index": 0.5,
                    "rgb": [181, 54, 122]
                  },
                  {
                    "index": 0.63,
                    "rgb": [229, 80, 100]
                  },
                  {
                    "index": 0.75,
                    "rgb": [251, 135, 97]
                  },
                  {
                    "index": 0.88,
                    "rgb": [254, 194, 135]
                  },
                  {
                    "index": 1,
                    "rgb": [252, 253, 191]
                  }
                ],
                "fillColorMapNshades": 10
              }
            }
          },
```