### PR TITLE
feat: add timeslider

### DIFF
--- a/app/client/src/components/viewer/ol/Map.vue
+++ b/app/client/src/components/viewer/ol/Map.vue
@@ -2,6 +2,7 @@
   <div id="ol-map-container" @click="$event => resetAfterSlide()" @mousemove="resetAfterSlide()">
     <!-- Map Controls -->
     <map-legend :color="color.primary" />
+    <time-slider :color="color.primary" />
     <div style="position: absolute; left: 20px; top: 10px">
       <login-button :color="color.primary"></login-button>
       <search-map
@@ -187,6 +188,7 @@ import Locate from './controls/Locate.vue';
 import Search from './controls/Search.vue';
 import RouteControls from './controls/RouteControls.vue';
 import Legend from './controls/Legend.vue';
+import TimeSlider from './controls/TimeSlider.vue'
 import Login from './controls/Login.vue';
 import Edit from './controls/Edit.vue';
 import ShareMap from './controls/ShareMap.vue';
@@ -217,6 +219,7 @@ export default {
     'add-post': AddPost,
     'overlay-popup': OverlayPopup,
     'map-legend': Legend,
+    'time-slider': TimeSlider,
     'login-button': Login,
     'zoom-control': ZoomControl,
     'full-screen': FullScreen,

--- a/app/client/src/components/viewer/ol/controls/Legend.vue
+++ b/app/client/src/components/viewer/ol/controls/Legend.vue
@@ -102,7 +102,12 @@
               <v-row
                 align="center"
                 justify="center"
-                v-if="item.get('displaySeries') && item.getVisible() && item.getLayers().getArray().length >= 2"
+                v-if="
+                  item.get('displaySeries') &&
+                  item.getVisible() &&
+                  item.getLayers().getArray().length >= 2 &&
+                  item.get('largeSlider') !== true
+                "
                 :key="'time-series' + index"
                 class="fill-height ma-0 pa-0"
               >

--- a/app/client/src/components/viewer/ol/controls/TimeSlider.vue
+++ b/app/client/src/components/viewer/ol/controls/TimeSlider.vue
@@ -1,0 +1,157 @@
+<template>
+  <div
+    v-if="!$vuetify.breakpoint.smAndDown && !!timeSeriesLayer && timeSeriesLayer.getVisible()"
+    :style="`position:absolute;left:50%;bottom:80px;opacity:90%;z-index:1000;width:450px;`"
+  >
+  <v-card class="mx-auto py-2 mx-4" max-width="600">
+      <!-- Current Layer Name -->
+      <v-row class="my-1" justify="center">
+        <span class="black--text text--darken-2 subtitle-2 font-weight-bold">
+          {{ timeSeriesLayer.getLayers().getArray()[timeSeriesLayer.get('activeLayerIndex')].get('name') }}
+        </span>
+      </v-row>
+      <v-card-text>
+        <v-slider
+          :color="color"
+          :step="1"
+          ticks
+          :value="timeSeriesLayer.get('activeLayerIndex') || timeSeriesLayer.get('defaultSeriesLayerIndex') || 0"
+          track-color="grey"
+          :max="timeSeriesLayer.getLayers().getArray().length - 1"
+          @change="activateTimeSeriesLayer($event, timeSeriesLayer)"
+          hide-details
+          center-affix
+        >
+          <template v-slot:prepend>
+            <v-btn
+              v-if="!timeSeriesLayer.get('isPlayDisabled')"
+              :color="color"
+              style="cursor: pointer"
+              class="elevation-0"
+              fab
+              small
+              icon
+              @click="isPlaying ? stop() : play()"
+            >
+              <v-icon>{{ isPlaying ? 'mdi-pause' : 'mdi-play' }}</v-icon>
+            </v-btn>
+          </template>
+          <template v-slot:append>
+            <v-btn
+              :color="color"
+              elevation="0"
+              icon
+              :disabled="timeSeriesLayer.get('activeLayerIndex') === 0"
+              @click="previous"
+            >
+              <v-icon>mdi-step-backward</v-icon>
+            </v-btn>
+            <v-btn
+              :color="color"
+              elevation="0"
+              icon
+              @click="next"
+              :disabled="timeSeriesLayer.get('activeLayerIndex') === timeSeriesLayer.getLayers().getArray().length - 1"
+            >
+              <v-icon>mdi-step-forward</v-icon>
+            </v-btn>
+          </template>
+        </v-slider>
+      </v-card-text>
+    </v-card>
+  </div>
+</template>
+<script>
+import {mapGetters} from 'vuex';
+import {Mapable} from '../../../../mixins/Mapable';
+
+export default {
+  mixins: [Mapable],
+  name: 'time-slider',
+  props: {
+    color: {type: String, default: '#4CAF50'},
+  },
+  data() {
+    return {
+      isPlaying: false,
+      playInterval: null,
+    };
+  },
+  methods: {
+    updateRows() {
+      const currentRes = this.map.getView().getResolution();
+      Object.keys(this.layers).forEach(key => {
+        const layer = this.layers[key];
+        const minRes = layer.getMinResolution();
+        const maxRes = layer.getMaxResolution();
+        if (currentRes >= minRes && currentRes <= maxRes) {
+          layer.set('isVisibleInResolution', true);
+        } else {
+          layer.set('isVisibleInResolution', false);
+        }
+        if (this.isReady === false) {
+          this.isReady = true;
+        }
+        this.$forceUpdate();
+      });
+    },
+    activateTimeSeriesLayer(index, layerGroup) {
+      const layers = layerGroup.getLayers().getArray();
+      layers.forEach(layer => {
+        layer.setVisible(false);
+      });
+      layers[index].setVisible(true);
+      this.$nextTick(() => {
+        this.updateRows();
+      });
+      layerGroup.set('activeLayerIndex', index);
+    },
+    play() {
+      this.isPlaying = true;
+      this.playInterval = setInterval(() => {
+        if (this.timeSeriesLayer.get('activeLayerIndex') === this.timeSeriesLayer.getLayers().getArray().length - 1) {
+          this.activateTimeSeriesLayer(0, this.timeSeriesLayer);
+        } else {
+          this.activateTimeSeriesLayer(this.timeSeriesLayer.get('activeLayerIndex') + 1, this.timeSeriesLayer);
+        }
+      }, this.timeSeriesLayer.get('playInterval') || 2000);
+    },
+    stop() {
+      this.isPlaying = false;
+      clearInterval(this.playInterval);
+    },
+    previous() {
+      this.stop();
+      const index = this.timeSeriesLayer.get('activeLayerIndex');
+      this.activateTimeSeriesLayer(index - 1, this.timeSeriesLayer);
+    },
+    next() {
+      this.stop();
+      const index = this.timeSeriesLayer.get('activeLayerIndex');
+      this.activateTimeSeriesLayer(index + 1, this.timeSeriesLayer);
+    },
+  },
+  computed: {
+    ...mapGetters('map', {
+      layers: 'layers',
+    }),
+    timeSeriesLayer() {
+      if (!this.layers) {
+        return null;
+      }
+      for (const layer of Object.values(this.layers)) {
+        if (layer.get('displaySeries') && layer.get('largeSlider')) {
+          return layer;
+        }
+      }
+
+      return null;
+    },
+  },
+};
+</script>
+<style lang="css" scoped>
+.v-input {
+  align-items: center;
+}
+</style>

--- a/app/client/src/factory/OlLayer.js
+++ b/app/client/src/factory/OlLayer.js
@@ -592,6 +592,9 @@ export const LayerFactory = {
       zIndex: lConf.zIndex,
       group: lConf.group,
       displaySeries: lConf.displaySeries,
+      playInterval: lConf.playInterval,
+      largeSlider: lConf.largeSlider,
+      isPlayDisabled: lConf.isPlayDisabled,
       defaultSeriesLayerIndex: lConf.defaultSeriesLayerIndex,
       activeLayerIndex: lConf.defaultSeriesLayerIndex || 0, // Used for layer series title in legend which is updated on layer change
       layers,


### PR DESCRIPTION
This PR adds the timeslider control for the GROUP layers. In order for this to be enabled the `largeSlider` property should be added in the GROUP layer config. 
```
   {
        "type": "GROUP",
       .............
        "displaySeries": true,
        "largeSlider": true,
       .............
  }
```

----
- To disable the play button the `"isPlayDisabled": false` can be used. In this case only "previous" and "next" buttons will be visible. 

- To configure the play interval time the property: `"playInterval: 2000"`  can be used. The 2000 is in milliseconds. 



