### PR TITLE
Timeslider fixes

### DIFF
--- a/app/api/controllers/auth/registerController.js
+++ b/app/api/controllers/auth/registerController.js
@@ -16,7 +16,7 @@ exports.validate = [
     .isEmail()
     .withMessage("Username must be a valid email address")
     .trim()
-    .normalizeEmail()
+    .normalizeEmail({gmail_remove_dots:false})
     .custom((value) => {
       return Logins.findOne({ where: { userName: value } }).then((user) => {
         if (user) {

--- a/app/client/src/components/viewer/ol/Map.vue
+++ b/app/client/src/components/viewer/ol/Map.vue
@@ -1162,17 +1162,8 @@ export default {
       this.popup.highlightLayer.getSource().clear();
       this.popup.worldExtentLayer.getSource().clear();
       this.popup.selectedCorpNetworkLayer.getSource().clear();
-      const mapLayers = [];
-      this.map
-        .getLayers()
-        .getArray()
-        .forEach(layer => {
-          if (layer.get('type') === 'GROUP') {
-            mapLayers.push(...layer.getLayers().getArray());
-          } else {
-            mapLayers.push(layer);
-          }
-        });
+      const mapLayers = this.map.getAllLayers();
+
       axios
         .all(promiseArray)
         .then(results => {

--- a/app/client/src/components/viewer/ol/Map.vue
+++ b/app/client/src/components/viewer/ol/Map.vue
@@ -188,7 +188,7 @@ import Locate from './controls/Locate.vue';
 import Search from './controls/Search.vue';
 import RouteControls from './controls/RouteControls.vue';
 import Legend from './controls/Legend.vue';
-import TimeSlider from './controls/TimeSlider.vue'
+import TimeSlider from './controls/TimeSlider.vue';
 import Login from './controls/Login.vue';
 import Edit from './controls/Edit.vue';
 import ShareMap from './controls/ShareMap.vue';

--- a/app/client/src/components/viewer/ol/controls/Edit.vue
+++ b/app/client/src/components/viewer/ol/controls/Edit.vue
@@ -461,17 +461,7 @@ export default {
       serverConfig: 'serverConfig',
     }),
     flatLayers() {
-      const layers = [];
-      this.map
-        .getLayers()
-        .getArray()
-        .forEach(layer => {
-          if (layer.get('type') === 'GROUP') {
-            layers.push(...layer.getLayers().getArray());
-          } else {
-            layers.push(layer);
-          }
-        });
+      const layers = this.map.getAllLayers();
       return layers;
     },
     isTranslatable() {

--- a/app/client/src/components/viewer/ol/controls/Legend.vue
+++ b/app/client/src/components/viewer/ol/controls/Legend.vue
@@ -306,7 +306,11 @@ export default {
     getSeriesActiveLayerTitle(layerGroup) {
       const layers = layerGroup.getLayers().getArray();
       const activeLayerIndex = layerGroup.get('activeLayerIndex') || 0;
-      const title = layers[activeLayerIndex].get('seriesDisplayName') || layers[activeLayerIndex].get('name');
+      const title =
+        layers[activeLayerIndex].get('legendDisplayName') &&
+        layers[activeLayerIndex].get('legendDisplayName')[this.$i18n.locale]
+          ? layers[activeLayerIndex].get('legendDisplayName')[this.$i18n.locale]
+          : layers[activeLayerIndex].get('name');
       return title;
     },
     isSliderVisible(layer) {

--- a/app/client/src/components/viewer/ol/controls/Legend.vue
+++ b/app/client/src/components/viewer/ol/controls/Legend.vue
@@ -102,12 +102,7 @@
               <v-row
                 align="center"
                 justify="center"
-                v-if="
-                  item.get('displaySeries') &&
-                  item.getVisible() &&
-                  item.getLayers().getArray().length >= 2 &&
-                  item.get('largeSlider') !== true
-                "
+                v-if="isSliderVisible(item)"
                 :key="'time-series' + index"
                 class="fill-height ma-0 pa-0"
               >
@@ -313,6 +308,22 @@ export default {
       const activeLayerIndex = layerGroup.get('activeLayerIndex') || 0;
       const title = layers[activeLayerIndex].get('seriesDisplayName') || layers[activeLayerIndex].get('name');
       return title;
+    },
+    isSliderVisible(layer) {
+      if (!layer.get('displaySeries')) {
+        return false;
+      }
+      if (this.$vuetify.breakpoint.smAndDown && layer.getVisible() && layer.getLayers().getArray().length >= 2) {
+        return true;
+      }
+      if (
+        !this.$vuetify.breakpoint.smAndDown &&
+        layer.getVisible() &&
+        layer.getLayers().getArray().length >= 2 &&
+        layer.get('largeSlider')
+      ) {
+        return false;
+      }
     },
   },
   mounted() {

--- a/app/client/src/components/viewer/ol/controls/TimeSlider.vue
+++ b/app/client/src/components/viewer/ol/controls/TimeSlider.vue
@@ -3,14 +3,14 @@
     v-if="!$vuetify.breakpoint.smAndDown && !!timeSeriesLayer && timeSeriesLayer.getVisible()"
     :style="`position:absolute;left:50%;bottom:80px;opacity:90%;z-index:1000;width:450px;`"
   >
-    <v-card class="mx-auto py-2 mx-4" max-width="600">
+    <v-card class="mx-auto py-1 mx-4" max-width="600">
       <!-- Current Layer Name -->
       <v-row class="my-1" justify="center">
         <span class="black--text text--darken-2 subtitle-2 font-weight-bold">
           {{ getSeriesActiveLayerTitle(timeSeriesLayer) }}
         </span>
       </v-row>
-      <v-card-text>
+      <v-card-text class="py-0 pb-1">
         <v-slider
           :color="color"
           :step="1"

--- a/app/client/src/components/viewer/ol/controls/TimeSlider.vue
+++ b/app/client/src/components/viewer/ol/controls/TimeSlider.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="!$vuetify.breakpoint.smAndDown && !!timeSeriesLayer && timeSeriesLayer.getVisible()"
-    :style="`position:absolute;left:calc(50% + 112px);transform:translateX(-50%);bottom:80px;opacity:90%;z-index:1000;minWidth:350px;width:calc(75% - 225px);`"
+    :style="`position:absolute;left:calc(50% + 112px);transform:translateX(-50%);bottom:80px;opacity:90%;z-index:1;minWidth:350px;width:calc(75% - 225px);`"
   >
     <v-card class="mx-auto py-1 mx-4">
       <!-- Current Layer Name -->

--- a/app/client/src/components/viewer/ol/controls/TimeSlider.vue
+++ b/app/client/src/components/viewer/ol/controls/TimeSlider.vue
@@ -3,11 +3,11 @@
     v-if="!$vuetify.breakpoint.smAndDown && !!timeSeriesLayer && timeSeriesLayer.getVisible()"
     :style="`position:absolute;left:50%;bottom:80px;opacity:90%;z-index:1000;width:450px;`"
   >
-  <v-card class="mx-auto py-2 mx-4" max-width="600">
+    <v-card class="mx-auto py-2 mx-4" max-width="600">
       <!-- Current Layer Name -->
       <v-row class="my-1" justify="center">
         <span class="black--text text--darken-2 subtitle-2 font-weight-bold">
-          {{ timeSeriesLayer.getLayers().getArray()[timeSeriesLayer.get('activeLayerIndex')].get('name') }}
+          {{ getSeriesActiveLayerTitle(timeSeriesLayer) }}
         </span>
       </v-row>
       <v-card-text>
@@ -129,6 +129,16 @@ export default {
       this.stop();
       const index = this.timeSeriesLayer.get('activeLayerIndex');
       this.activateTimeSeriesLayer(index + 1, this.timeSeriesLayer);
+    },
+    getSeriesActiveLayerTitle(layerGroup) {
+      const layers = layerGroup.getLayers().getArray();
+      const activeLayerIndex = layerGroup.get('activeLayerIndex') || 0;
+      const title =
+        layers[activeLayerIndex].get('legendDisplayName') &&
+        layers[activeLayerIndex].get('legendDisplayName')[this.$i18n.locale]
+          ? layers[activeLayerIndex].get('legendDisplayName')[this.$i18n.locale]
+          : layers[activeLayerIndex].get('name');
+      return title;
     },
   },
   computed: {

--- a/app/client/src/components/viewer/ol/controls/TimeSlider.vue
+++ b/app/client/src/components/viewer/ol/controls/TimeSlider.vue
@@ -1,9 +1,9 @@
 <template>
   <div
     v-if="!$vuetify.breakpoint.smAndDown && !!timeSeriesLayer && timeSeriesLayer.getVisible()"
-    :style="`position:absolute;left:50%;bottom:80px;opacity:90%;z-index:1000;width:450px;`"
+    :style="`position:absolute;left:calc(50% + 112px);transform:translateX(-50%);bottom:80px;opacity:90%;z-index:1000;minWidth:350px;width:calc(75% - 225px);`"
   >
-    <v-card class="mx-auto py-1 mx-4" max-width="600">
+    <v-card class="mx-auto py-1 mx-4">
       <!-- Current Layer Name -->
       <v-row class="my-1" justify="center">
         <span class="black--text text--darken-2 subtitle-2 font-weight-bold">

--- a/app/client/src/factory/OlLayer.js
+++ b/app/client/src/factory/OlLayer.js
@@ -95,10 +95,10 @@ export const LayerFactory = {
     if ((stylePropFnRef && !styleRef) || label) {
       styleRef = 'baseStyle';
     }
-    if (styleRef === "htmlLayerStyle") {
+    if (styleRef === 'htmlLayerStyle') {
       return styleRefs.htmlLayerStyle();
     }
-    if (styleRef === "popupInfoStyle") {
+    if (styleRef === 'popupInfoStyle') {
       return styleRefs.popupInfoStyle();
     }
     if (!stylePropFnRef) {

--- a/app/client/src/factory/OlLayer.js
+++ b/app/client/src/factory/OlLayer.js
@@ -560,9 +560,16 @@ export const LayerFactory = {
     const layersConfig = lConf.layers;
     if (Array.isArray(layersConfig)) {
       layersConfig.forEach((layerConfig, index) => {
-        const layer = this.getInstance(layerConfig);
-        if (zIndex) {
-          layer.setZIndex(zIndex + index);
+        let layer;
+        if (Array.isArray(layerConfig.layers)) {
+          // If the layerConfig has layers, it's a group - create a nested group
+          layer = this.createGroupLayer(layerConfig, zIndex);
+        } else {
+          // It's a single layer
+          layer = this.getInstance(layerConfig);
+          if (zIndex) {
+            layer.setZIndex(zIndex + index);
+          }
         }
         layers.push(layer);
         if (lConf.displaySeries) {

--- a/app/client/src/store/modules/map.js
+++ b/app/client/src/store/modules/map.js
@@ -199,7 +199,14 @@ const actions = {
       if (layer instanceof LayerGroup) {
         const layersArray = layer.getLayers().getArray();
         layersArray.forEach(l => {
-          layers[l.get('name')] = l;
+          if (l instanceof LayerGroup) {
+            const subLayers = l.getLayers().getArray();
+            subLayers.forEach(subLayer => {
+              layers[subLayer.get('name')] = subLayer;
+            });
+          } else {
+            layers[l.get('name')] = l;
+          }
         });
       } else {
         layers[layer.get('name')] = layer;

--- a/app/client/src/utils/Layer.js
+++ b/app/client/src/utils/Layer.js
@@ -87,18 +87,7 @@ export function getLayerByLid(lid, olMap) {
  * @return {ol.layer.Base[]} Array of all map layers
  */
 export function getAllChildLayers(olMap) {
-  const allLayers = [];
-  olMap
-    .getLayers()
-    .getArray()
-    .forEach(layer => {
-      if (layer instanceof LayerGroup) {
-        const layers = layer.getLayers().getArray();
-        allLayers.push(...layers);
-      } else {
-        allLayers.push(layer);
-      }
-    });
+  const allLayers = olMap.getAllLayers();
   return allLayers;
 }
 


### PR DESCRIPTION
- Should title from legend name 
- Chaage height of the slider to 90px.
- Make the width responsive
- Fix mobile timeslider issues. 
- Add the subgroups 
For adding the subgroups a structure like below can be used: 
```

      {
        "type": "GROUP",
        "name": "wateruse",
        "minResolution": 1,
        "maxResolution": 68000,
        "displayInLegend": true,
        "legendDisplayName": {
          "en": "Groundwater use",
          "de": "Wassernutzung",
          "es": "Uso del agua"
        },
        "legendIcon": "",
        "visible": true,
        "displaySidebarInfo": true,
        "group": "media",
        "attributions": "",
        "displaySeries": true,
        "largeSlider": true,
        "defaultSeriesLayerIndex": 0,
        "playInterval": "2000",
        "layers": [
          {
            "type": "GROUP",
            "name": "counties_1990_1993",
            "visible": true,
            "legendDisplayName": {
              "en": "Water use 1990-1993",
              "es": "Water use 1990-1993",
              "de": "Water use 1990-1993"
            },
            "layers": [
              {
                "type": "VECTORTILE",
                "name": "counties_1990",
                "url": "./geoserver/gwc/service/tms/1.0.0/workspace1:counties_1990@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf",
                "queryable": true,
                "displayInLegend": true,
                "legendDisplayName": {
                  "en": "Water use 1990",
                  "es": "Water use 1990",
                  "de": "Water use 1990"
                },
                "format": "MVT",
                "renderMode": "hybrid",
                "visible": true,
                "zIndex": 1000,
                "opacity": 0.7,
                "minResolution": 80,
                "maxResolution": 64000,
                "hoverable": true,
                "style": {
                  "stylePropFnRef": {
                    "fillColor": "af_irr_1990",
                    "fillColorFn": "colorMapStyle",
                    "fillColorMap": "portland"
                  },
                  "strokeColor": "lightgray",
                  "strokeWidth": 2
                }
              },
              {
                "type": "VECTORTILE",
                "name": "counties_1991",
                "url": "./geoserver/gwc/service/tms/1.0.0/workspace1:counties_1991@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf",
                "queryable": true,
                "displayInLegend": true,
                "legendDisplayName": {
                  "en": "Water use 1991",
                  "es": "Water use 1991",
                  "de": "Water use 1991"
                },
                "format": "MVT",
                "renderMode": "hybrid",
                "visible": true,
                "zIndex": 1000,
                "opacity": 0.7,
                "minResolution": 80,
                "maxResolution": 64000,
                "hoverable": true,
                "style": {
                  "stylePropFnRef": {
                    "fillColor": "af_irr_1991",
                    "fillColorFn": "colorMapStyle",
                    "fillColorMap": "portland"
                  },
                  "strokeColor": "lightgray",
                  "strokeWidth": 2
                }
              }
            ]
          },
```


