### PR TITLE
fix(client): remove sourceLanguage from translate keys

### DIFF
--- a/app/api/controllers/other/translateController.js
+++ b/app/api/controllers/other/translateController.js
@@ -81,6 +81,7 @@ exports.translateAllFeatures = async (req, res) => {
         );
 
         const targetLanguages = Object.keys(langVariants)
+          .filter((lang) => lang != req.query.sourceLanguage);
 
         if (response[0].length > 0) {
           let partition = 0;


### PR DESCRIPTION
Exclude the source language from the input to the "translations" column